### PR TITLE
Added jk-roam-learn.

### DIFF
--- a/emacs/.emacs.d/modules/jk-roam-learn.el
+++ b/emacs/.emacs.d/modules/jk-roam-learn.el
@@ -1,0 +1,71 @@
+(require 'org-roam)
+
+(defvar jk/roam-learn-overlays '()
+  "List of all overlays that are applied by `jk-roam-learn'")
+
+(defcustom jk/roam-registered-tags '()
+  "List of tags that are used by `jk-roam-learn'")
+
+(defun jk/roam-learn-node (node)
+  "Learn a NODE. This will hide the buffer contents and only show the title of
+the NODE. To reveal the node use `jk/roam-learn-reveal'."
+  (interactive)
+  (org-roam-node-visit node)
+  (let ((dest-pos))
+    (save-excursion
+      (goto-char (point-min))
+      (setq dest-pos (re-search-forward "#\\+\\(TITLE\\|Title\\|title\\):"
+					nil t))
+      (goto-char dest-pos)
+      (next-line)
+      (beginning-of-line)
+      (let ((overlay (make-overlay (point) (point-max) (current-buffer))))
+	(overlay-put overlay 'display "...")
+	(push overlay jk/roam-learn-overlays)))
+    (goto-char (1+ dest-pos))))
+
+(defun jk/roam-learn-reveal ()
+  "Remove the overlay from the current buffer."
+  (interactive)
+  (dolist (overlay jk/roam-learn-overlays)
+    (when (string-equal (buffer-name (current-buffer))
+			(buffer-name (overlay-buffer overlay)))
+      (delete-overlay overlay)
+      (message "Revealing..."))))
+
+(defun jk/roam-learn-reveal-all ()
+  "Remove all overlays that are currently applied by this package."
+  (interactive)
+  (unless jk/roam-learn-overlays
+    (dolist (overlay dk/roam-learn-overlays)
+      (delete-overlay overlay))))
+
+(defun jk/roam-learn-select-random-node (nodes)
+  "Take a random node from NODES and return it."
+  (cdr (seq-random-elt (nodes))))
+
+(defun jk/roam-learn-matches-tag (node tag)
+  "Check if NODE has TAG as one of it's members."
+  (member tag (org-roam-node-tags node)))
+
+(defun jk/roam-learn-get-nodes-matching-tag (tag)
+  (let ((nodes (org-roam-node-list))
+	(nodes (cl-remove-if-not
+		(lambda (node) (jk/roam-learn-matches-tag node tag)))))
+    nodes))
+
+(defun jk/roam-learn ()
+  "Select a tag and learn a random node."
+  (interactive)
+  (let ((tag (completing-read "Tag: " jk/roam-registered-tags nil t))
+	(nodes (jk/roam-learn-get-nodes-matching-tag tag))
+	(result (jk/roam-learn-select-random-node nodes)))
+    (jk/roam-learn-node result)))
+
+(defun jk/roam-learn-random-by-tag (tag)
+  "Visit a random node that has TAG."
+  (let ((nodes (jk/roam-learn-get-nodes-matching-tag tag))
+	(node (jk/roam-learn-select-random-node nodes)))
+    (jk/roam-learn-node node)))
+
+(provide 'jk-roam-learn)

--- a/emacs/.emacs.d/modules/jk-roam.el
+++ b/emacs/.emacs.d/modules/jk-roam.el
@@ -16,7 +16,7 @@
 				  :immediate-finish t
 				  :unnarrowed t
 				  )
-                 ("e" "ETH" plain
+				 ("e" "ETH" plain
 				  "%?"
 				  :if-new (file+head "eth/%<%Y%m%d>-${slug}.org"
 						     "#+TITLE: ${title}\n#+FILETAGS: \n#+DATE: "
@@ -24,7 +24,7 @@
 				  :immediate-finish t
 				  :unnarrowed t
 				  )
-                 ("d" "Docs" plain
+				 ("d" "Docs" plain
 				  "%?"
 				  :if-new (file+head "docs/%<%Y%m%d>-${slug}.org"
 						     "#+TITLE: ${title}\n#+FILETAGS: \n#+DATE: "
@@ -32,7 +32,7 @@
 				  :immediate-finish t
 				  :unnarrowed t
 				  )
-                 ("o" "Output" plain
+				 ("o" "Output" plain
 				  "%?"
 				  :if-new (file+head "out/%<%Y%m%d>-${slug}.org"
 						     "#+TITLE: ${title}\n#+FILETAGS: \n#+DATE: "
@@ -75,49 +75,29 @@
 (setq org-roam-node-display-template
       (concat "${type:10} - ${tags:30}: ${title:*}"))
 
+(require 'jk-roam-learn)
+
+(setq jk/roam-registered-tags '("discmath" "and" "linalg" "eprog"))
+
 (defun jk/get-specific-random-discmath ()
-    "get discmath node"
-    (interactive)
-    (org-roam-node-random nil 'jk/org-roam-is-discmath)
-    )
+  "get discmath node"
+  (interactive)
+  (jk/roam-learn-random-by-tag "discmath"))
 
 (defun jk/get-specific-random-and ()
-    "get and node"
-    (interactive)
-    (org-roam-node-random nil 'jk/org-roam-is-and)
-    )
+  "get and node"
+  (interactive)
+  (jk/roam-learn-random-by-tag "and"))
 
 (defun jk/get-specific-random-linalg ()
-    "get linalg node"
-    (interactive)
-    (org-roam-node-random nil 'jk/org-roam-is-linalg)
-    )
+  "get linalg node"
+  (interactive)
+  (jk/roam-learn-random-by-tag "linalg"))
 
 (defun jk/get-specific-random-eprog ()
-    "get discmath node"
-    (interactive)
-    (org-roam-node-random nil 'jk/org-roam-is-eprog)
-    )
-
-(defun jk/org-roam-is-discmath (node)
-  "Is the node tagged as discmath"
-  (member "discmath" (org-roam-node-tags node))
-  )
-
-(defun jk/org-roam-is-and (node)
-  "Is the node tagged as discmath"
-  (member "and" (org-roam-node-tags node))
-  )
-
-(defun jk/org-roam-is-linalg (node)
-  "Is the node tagged as discmath"
-  (member "linalg" (org-roam-node-tags node))
-  )
-
-(defun jk/org-roam-is-eprog (node)
-  "Is the node tagged as discmath"
-  (member "eprog" (org-roam-node-tags node))
-  )
+  "get discmath node"
+  (interactive)
+  (jk/roam-learn-random-by-tag "eprog"))
 
 (use-package org-roam-ui
   :after org-roam


### PR DESCRIPTION
# Warning
The added feature has only been partially tested. It is possible that some things may break, due to the fact that I do not have the tags and structure to test all functions. It is not possible that the code can modify/delete text. 

# Options/features
- Set the variable jk/roam-registered-tags to a list of strings. The strings are the tag names. You can then interactively call jk/roam-learn to select a tag and get a random node to learn.
- If a node should be revealed call the function jk/roam-learn-reveal. It is probably best to bind this to a key.
- If the learning session is finished or something breaks: jk/roam-learn-reveal-all. This will clean up all buffers that were visually modified by jk-roam-learn.

# Requires
This feature probably requires emacs in gui mode because it uses overlays to modify the appearance of the buffer.